### PR TITLE
add retry in user_page and fix portal test

### DIFF
--- a/lib/pom/Users_page.js
+++ b/lib/pom/Users_page.js
@@ -48,8 +48,12 @@ class Users_page extends Page {
   selectReadAccessForPermission(permissionName) {
     const $$radioButtons = $$(`input[name="user_permissions.${permissionName}"]`);
     wdioExpect($$radioButtons).toBeElementsArrayOfSize({gte: 2});
+    $$radioButtons[1].waitForClickable();
     $$radioButtons[1].click();
     browser.pause(1000);
+    if ($$radioButtons[1].getValue() !== 'read'){
+      $$radioButtons[1].click();
+    }
     wdioExpect($$radioButtons[1]).toHaveValue('read');
   }
 }

--- a/test/specs/portal_settings/api_access_settings_test.js
+++ b/test/specs/portal_settings/api_access_settings_test.js
@@ -35,11 +35,11 @@ describe('Portal Settings - API access manipulations', () => {
   it('User should see saved values after re-load values', () => {
     browser.refresh();
     admin_settings_page.API_ACCESS_TAB_BUTTON.click();
+    wdioExpect(admin_settings_page.REDIRECT_URL_INPUT).toHaveValue(redirectUrl);
+    wdioExpect(admin_settings_page.NUMBER_OF_ALLOWED_REQUESTS_INPUT).toHaveValue(numberfAllowedRequests);
     expect(admin_settings_page.MANUAL_ACCESS_APPROVAL_TOGGLE.isSelected()).to.be.true;
     expect(admin_settings_page.HIDE_API_SECRET_TOGGLE.isSelected()).to.be.true;
     expect(admin_settings_page.MULTIPLE_API_SUBSCRIPTION_TOGGLE.isSelected()).to.be.true;
     expect(admin_settings_page.THIRD_PARTY_REDIRECT_TOGGLE.isSelected()).to.be.true;
-    wdioExpect(admin_settings_page.REDIRECT_URL_INPUT).toHaveValue(redirectUrl);
-    wdioExpect(admin_settings_page.NUMBER_OF_ALLOWED_REQUESTS_INPUT).toHaveValue(numberfAllowedRequests);
   });
 });


### PR DESCRIPTION
- add retry in user_page (selecting access type)
- move dynamic assertions (wdioExpect) before chai assertions in portal test. Test now should wait until values on page will be loaded