### PR TITLE
[TT-17030] Migrate workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -25,6 +25,14 @@ jobs:
     runs-on: ${{ matrix.platform }}
     
     steps:
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+      with:
+        app-id: ${{ secrets.PROBE_APP_ID }}
+        private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+        owner: TykTechnologies
+
     - name: Install Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2.4.1
       with:
@@ -32,7 +40,7 @@ jobs:
 
     - name: Fix private module deps
       env:
-        TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
         git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
     
@@ -40,7 +48,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: tyk-analytics-tests
-        token: ${{ secrets.ORG_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         submodules: true
 
     - name: Set up Chrome with proper version
@@ -52,7 +60,7 @@ jobs:
     - name: Check if Dashboard branch exists
       id: check_test_branch
       env:
-        TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        TOKEN: '${{ steps.app-token.outputs.token }}'
       run: |
         echo "::set-output name=branch::master"
         if git ls-remote --exit-code --heads https://${TOKEN}@github.com/TykTechnologies/tyk-analytics ${{ github.base_ref	}}; then
@@ -71,14 +79,14 @@ jobs:
       with:
         repository: TykTechnologies/tyk-analytics
         path: tyk-analytics
-        token: ${{ secrets.ORG_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         submodules: true
         ref: ${{ steps.check_test_branch.outputs.branch	 }}
 
     - name: Check if GW branch exists
       id: check_GW_branch
       env:
-        TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        TOKEN: '${{ steps.app-token.outputs.token }}'
       run: |
         echo "::set-output name=branch::master"
         if git ls-remote --exit-code --heads https://${TOKEN}@github.com/TykTechnologies/tyk ${{ github.base_ref	}}; then
@@ -97,7 +105,7 @@ jobs:
       with:
         repository: TykTechnologies/tyk
         path: tyk
-        token: ${{ secrets.ORG_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         submodules: true
         ref: ${{ steps.check_GW_branch.outputs.branch	 }}
 
@@ -109,7 +117,7 @@ jobs:
         GW_REPO_PATH: /home/runner/work/tyk-analytics-tests/tyk-analytics-tests/tyk
         GOPATH: /home/runner/work/tyk-analytics-tests/
         GOPRIVATE: github.com/TykTechnologies
-        TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+        TOKEN: ${{ steps.app-token.outputs.token }}
         GO_VERSION: ${{ matrix.go-version }}
       working-directory: tyk-analytics-tests
 
@@ -180,7 +188,7 @@ jobs:
           Commit: ${{ github.event.after }} ${{ github.event.commits[0].message }}
           Triggered by: ${{ github.event_name }} (@${{ github.actor }})
           [Execution page](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-        repo-token: ${{ secrets.ORG_GH_TOKEN }}
+        repo-token: ${{ steps.app-token.outputs.token }}
         allow-repeats: true
       env:
         STATUS: "${{ steps.test_execution.outcome == 'success' && ':white_check_mark:' || ':no_entry_sign:' }}"

--- a/.github/workflows/internal_postgres.yml
+++ b/.github/workflows/internal_postgres.yml
@@ -25,6 +25,14 @@ jobs:
     runs-on: ${{ matrix.platform }}
     
     steps:
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+      with:
+        app-id: ${{ secrets.PROBE_APP_ID }}
+        private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+        owner: TykTechnologies
+
     - name: Install Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2.4.1
       with:
@@ -32,7 +40,7 @@ jobs:
 
     - name: Fix private module deps
       env:
-        TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
         git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
     
@@ -40,7 +48,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: tyk-analytics-tests
-        token: ${{ secrets.ORG_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         submodules: true
 
     - name: Set up Chrome with proper version
@@ -52,7 +60,7 @@ jobs:
     - name: Check if Dashboard branch exists
       id: check_test_branch
       env:
-        TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        TOKEN: '${{ steps.app-token.outputs.token }}'
       run: |
         echo "::set-output name=branch::master"
         if git ls-remote --exit-code --heads https://${TOKEN}@github.com/TykTechnologies/tyk-analytics ${{ github.base_ref	}}; then
@@ -71,14 +79,14 @@ jobs:
       with:
         repository: TykTechnologies/tyk-analytics
         path: tyk-analytics
-        token: ${{ secrets.ORG_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         submodules: true
         ref: ${{ steps.check_test_branch.outputs.branch	 }}
 
     - name: Check if GW branch exists
       id: check_GW_branch
       env:
-        TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        TOKEN: '${{ steps.app-token.outputs.token }}'
       run: |
         echo "::set-output name=branch::master"
         if git ls-remote --exit-code --heads https://${TOKEN}@github.com/TykTechnologies/tyk ${{ github.base_ref	}}; then
@@ -97,7 +105,7 @@ jobs:
       with:
         repository: TykTechnologies/tyk
         path: tyk
-        token: ${{ secrets.ORG_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         submodules: true
         ref: ${{ steps.check_GW_branch.outputs.branch	 }}
 
@@ -109,7 +117,7 @@ jobs:
         GW_REPO_PATH: /home/runner/work/tyk-analytics-tests/tyk-analytics-tests/tyk
         GOPATH: /home/runner/work/tyk-analytics-tests/
         GOPRIVATE: github.com/TykTechnologies
-        TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+        TOKEN: ${{ steps.app-token.outputs.token }}
         GO_VERSION: ${{ matrix.go-version }}
       working-directory: tyk-analytics-tests
 
@@ -180,7 +188,7 @@ jobs:
           Commit: ${{ github.event.after }} ${{ github.event.commits[0].message }}
           Triggered by: ${{ github.event_name }} (@${{ github.actor }})
           [Execution page](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-        repo-token: ${{ secrets.ORG_GH_TOKEN }}
+        repo-token: ${{ steps.app-token.outputs.token }}
         allow-repeats: true
       env:
         STATUS: "${{ steps.test_execution.outcome == 'success' && ':white_check_mark:' || ':no_entry_sign:' }}"

--- a/.github/workflows/on_demand.yml
+++ b/.github/workflows/on_demand.yml
@@ -26,6 +26,14 @@ jobs:
     runs-on: ${{ matrix.platform }}
     
     steps:
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+      with:
+        app-id: ${{ secrets.PROBE_APP_ID }}
+        private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+        owner: TykTechnologies
+
     - name: Install Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2.4.1
       with:
@@ -33,7 +41,7 @@ jobs:
 
     - name: Fix private module deps
       env:
-        TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
         git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
     
@@ -41,7 +49,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: tyk-analytics-tests
-        token: ${{ secrets.ORG_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         submodules: true
     
     - name: Checkout Dash repository
@@ -49,7 +57,7 @@ jobs:
       with:
         repository: TykTechnologies/tyk-analytics
         path: tyk-analytics
-        token: ${{ secrets.ORG_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         submodules: true
         ref: ${{ github.event.inputs.dashboard_branch }}
 
@@ -59,7 +67,7 @@ jobs:
         TYK_DB_LICENSEKEY: ${{secrets.DASH_LICENSE}}
         DASH_REPO_PATH: /home/runner/work/tyk-analytics-tests/tyk-analytics-tests/tyk-analytics
         GOPRIVATE: github.com/TykTechnologies
-        TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+        TOKEN: ${{ steps.app-token.outputs.token }}
       working-directory: tyk-analytics-tests
 
     - name: Install test dependecies
@@ -109,7 +117,7 @@ jobs:
           Commit: ${{ github.event.after }} ${{ github.event.commits[0].message }}
           Triggered by: ${{ github.event_name }} (@${{ github.actor }})
           [Execution page](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-        repo-token: ${{ secrets.ORG_GH_TOKEN }}
+        repo-token: ${{ steps.app-token.outputs.token }}
         allow-repeats: true
       env:
         STATUS: "${{ steps.test_execution.outcome == 'success' && ':white_check_mark:' || ':no_entry_sign:' }}"

--- a/.github/workflows/tyk-demo-ui.yml
+++ b/.github/workflows/tyk-demo-ui.yml
@@ -31,6 +31,14 @@ jobs:
     runs-on: ${{ matrix.platform }}
     
     steps:
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+      with:
+        app-id: ${{ secrets.PROBE_APP_ID }}
+        private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+        owner: TykTechnologies
+
     - name: Install Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2.4.1
       with:
@@ -38,7 +46,7 @@ jobs:
 
     - name: Fix private module deps
       env:
-        TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
         git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
 


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` (PAT) with GitHub App token generation using `actions/create-github-app-token` in 4 workflow files:
  - `internal_postgres.yml` (10 token references)
  - `internal.yml` (10 token references)
  - `on_demand.yml` (5 token references)
  - `tyk-demo-ui.yml` (1 token reference)
- Covers: checkout tokens, `git config insteadOf` patterns, `git ls-remote` auth, docker-compose env vars, and PR comment `repo-token`
- **Note:** `internal-playwright.yml` and `ui_test.yml` also contain `ORG_GH_TOKEN` references but were not in scope for this PR

## Test plan
- [ ] Verify `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` secrets are configured in the repo
- [ ] Trigger each workflow and confirm they can check out private repos and run tests
- [ ] Verify docker-compose environments still receive valid tokens
- [ ] Confirm PR comments are still posted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)