### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/internal-playwright.yml
+++ b/.github/workflows/internal-playwright.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
-        git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+        git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
     
     - name: Checkout of Framework
       uses: actions/checkout@v2

--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -42,7 +42,7 @@ jobs:
       env:
         TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
-        git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+        git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
     
     - name: Checkout of Framework
       uses: actions/checkout@v2

--- a/.github/workflows/internal_postgres.yml
+++ b/.github/workflows/internal_postgres.yml
@@ -42,7 +42,7 @@ jobs:
       env:
         TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
-        git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+        git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
     
     - name: Checkout of Framework
       uses: actions/checkout@v2

--- a/.github/workflows/on_demand.yml
+++ b/.github/workflows/on_demand.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
-        git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+        git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
     
     - name: Checkout of Framework
       uses: actions/checkout@v2

--- a/.github/workflows/tyk-demo-ui.yml
+++ b/.github/workflows/tyk-demo-ui.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         TOKEN: '${{ steps.app-token.outputs.token }}'
       run: >
-        git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+        git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
 
     - name: Checkout test repo repostory
       uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
- Fix `git config insteadOf` pattern across 5 workflow files to use `x-access-token:` prefix and trailing slashes
- The bare token pattern fails when `actions/checkout` has set up a credential helper; the `x-access-token:` prefix ensures the URL rewrite takes precedence

## Files changed
- `.github/workflows/internal.yml` — 1 replacement
- `.github/workflows/internal_postgres.yml` — 1 replacement
- `.github/workflows/internal-playwright.yml` — 1 replacement
- `.github/workflows/on_demand.yml` — 1 replacement
- `.github/workflows/tyk-demo-ui.yml` — 1 replacement

## Test plan
- [ ] Verify all five workflow files resolve private Go module deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)